### PR TITLE
Add nested objects  support and 'OR' logical operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ https://example.com/?sortBy=firstName:asc
 
 **none** - `where=firstName: none string(John)` or `where=firstName: none John`
 
+**OR** - `where=OR:[ firstName: contains Jhon, lastName: contains Doe]`
+
 ## Where types realized:
 
 **string** - `where=firstName: contains string(John)`
@@ -101,6 +103,16 @@ https://example.com/?where=id: not int(12)
 * Select all rows where id is greater than 1 and email contains `@gmail.com`
 ```
 https://example.com/?where=id: gt int(1), email: contains @gmail.com
+```
+
+* Select all rows where ids are 1, 2 or 3 or age is 18
+```
+https://example.com/?where=OR:[id: in array(1,2,3), age: int(18)]
+```
+
+* Select all rows where the user's email contains `@gmail.com`.
+```
+https://example.com/?where=user.email: contains @gmail.com
 ```
 
 # WherePipe vs OrderByPipe

--- a/test/prisma/where.pipe.spec.ts
+++ b/test/prisma/where.pipe.spec.ts
@@ -102,6 +102,59 @@ describe('WherePipe', () => {
     });
   });
 
+  it('should parse "." from string "product.details.color.hexadecimal: contains string(#FFFF)"', () => {
+    const string = 'product.details.color.hexadecimal: contains string(#FFFF)';
+
+    expect(pipe.transform(string)).toEqual({
+      product: {
+        is: {
+          details: {
+            is: {
+              color: {
+                is: {
+                  hexadecimal: {
+                    contains: "#FFFF"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+    });
+  });
+
+  it('should parse "OR" from string "OR:[ firstName: contains Jhon, lastName: contains Doe]"', () => {
+    const string = "OR:[ firstName: contains Jhon, lastName: contains Doe]";
+
+    expect(pipe.transform(string)).toEqual({
+      OR: [
+        { firstName: { contains: "Jhon" } },
+        { lastName: { contains: "Doe" } },
+      ],
+    });
+  });
+
+  it('should parse "OR" with array values from string "OR:[id:in array(int(1),int(2),int(3)), user: contains Jhon]"', () => {
+    const string =
+      "OR:[id:in array(int(1),int(2),int(3)), user: contains Jhon]";
+
+    expect(pipe.transform(string)).toEqual({
+      OR: [
+        {
+          id: {
+            in: [1, 2, 3]
+          }
+        },
+        {
+          user: {
+            contains: "Jhon"
+          }
+        }
+      ],
+    });
+  });
+
   it('should be defined', () => {
     expect(pipe).toBeDefined();
   });


### PR DESCRIPTION
##Problem
currently does not support logical operators such as OR, nor does it support nested objects.

##Solution
Added support for nested objects with ".", also added support for the logical operator "OR".

##Note: 
3 additional tests have been performed